### PR TITLE
Kotlin Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ Import to your project with the following statement:
     compile 'io.ashdavies.rx:rx-tasks:{latest-version}'
 ```
 
-Any `Task` returned from the Google Mobile Services API can simply be wrapped in the appropriate call.
+Any `Task` returned from the Google Mobile Services API can simply be wrapped in the appropriate call using an extension function.
 
 ```android
-    Single<AuthResult> result = RxTasks.single(FirebaseAuth.getInstance().signInAnonymously());
+    Single<AuthResult> result = FirebaseAuth.getInstance()
+      .signInAnonymously()
+      .toSingle()
 ```

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,27 +11,26 @@ ext.configuration = [
 
 ext.versions = [
     annotations: [
-        jsr305: '3.0.1'
+        jsr305: '3.0.2'
     ],
 
     android    : [
-        support: '25.3.1',
+        support: '27.0.1',
         tools  : '3.0.1'
     ],
 
     google     : [
         play    : [
-            services: '10.2.0'
+            services: '11.6.2'
         ],
-        services: '3.1.0'
+        services: '3.1.2'
     ],
 
-    kotlin     : '1.2.0',
+    kotlin     : '1.2.10',
 
     rx         : [
-        java    : '2.0.6',
+        java    : '2.1.7',
         android : '2.0.1',
-        firebase: '1.3.3',
     ],
 
     jUnit      : '4.12',

--- a/library/src/main/kotlin/io/ashdavies/rx/rxtasks/CompletableTaskOnSubscribe.kt
+++ b/library/src/main/kotlin/io/ashdavies/rx/rxtasks/CompletableTaskOnSubscribe.kt
@@ -4,6 +4,6 @@ import com.google.android.gms.tasks.Task
 import io.reactivex.CompletableEmitter
 import io.reactivex.CompletableOnSubscribe
 
-internal class CompletableTaskOnSubscribe @JvmOverloads constructor(
+internal class CompletableTaskOnSubscribe(
     task: Task<Void>, factory: TaskListenerFactory<Void, CompletableEmitter> = CompletableTaskListenerFactory()
 ) : TaskOnSubscribe<Void, CompletableEmitter>(task, factory), CompletableOnSubscribe

--- a/library/src/main/kotlin/io/ashdavies/rx/rxtasks/RxTasks.kt
+++ b/library/src/main/kotlin/io/ashdavies/rx/rxtasks/RxTasks.kt
@@ -1,19 +1,10 @@
 package io.ashdavies.rx.rxtasks
 
 import com.google.android.gms.tasks.Task
-import io.reactivex.Completable
-import io.reactivex.Single
 
-class RxTasks private constructor() {
+object RxTasks {
 
-  companion object {
+  fun completable(task: Task<Void>) = task.toCompletable()
 
-    fun completable(task: Task<Void>): Completable {
-      return Completable.create(CompletableTaskOnSubscribe(task))
-    }
-
-    fun <T> single(task: Task<T>): Single<T> {
-      return Single.create(SingleTaskOnSubscribe(task))
-    }
-  }
+  fun <T> single(task: Task<T>) = task.toSingle()
 }

--- a/library/src/main/kotlin/io/ashdavies/rx/rxtasks/SingleTaskListenerFactory.kt
+++ b/library/src/main/kotlin/io/ashdavies/rx/rxtasks/SingleTaskListenerFactory.kt
@@ -2,9 +2,9 @@ package io.ashdavies.rx.rxtasks
 
 import io.reactivex.SingleEmitter
 
-internal class SingleTaskListenerFactory<Result> : TaskListenerFactory<Result, SingleEmitter<Result>> {
+internal class SingleTaskListenerFactory<T> : TaskListenerFactory<T, SingleEmitter<T>> {
 
-  override fun createOnSuccessListener(emitter: SingleEmitter<Result>) = SingleEmitterSuccessListener(emitter)
+  override fun createOnSuccessListener(emitter: SingleEmitter<T>) = SingleEmitterSuccessListener(emitter)
 
-  override fun createOnFailureListener(emitter: SingleEmitter<Result>) = SingleEmitterFailureListener(emitter)
+  override fun createOnFailureListener(emitter: SingleEmitter<T>) = SingleEmitterFailureListener(emitter)
 }

--- a/library/src/main/kotlin/io/ashdavies/rx/rxtasks/SingleTaskOnSubscribe.kt
+++ b/library/src/main/kotlin/io/ashdavies/rx/rxtasks/SingleTaskOnSubscribe.kt
@@ -4,6 +4,6 @@ import com.google.android.gms.tasks.Task
 import io.reactivex.SingleEmitter
 import io.reactivex.SingleOnSubscribe
 
-internal class SingleTaskOnSubscribe<Result> @JvmOverloads constructor(
-    task: Task<Result>, factory: TaskListenerFactory<Result, SingleEmitter<Result>> = SingleTaskListenerFactory()
-) : TaskOnSubscribe<Result, SingleEmitter<Result>>(task, factory), SingleOnSubscribe<Result>
+internal class SingleTaskOnSubscribe<T>(
+    task: Task<T>, factory: TaskListenerFactory<T, SingleEmitter<T>> = SingleTaskListenerFactory()
+) : TaskOnSubscribe<T, SingleEmitter<T>>(task, factory), SingleOnSubscribe<T>

--- a/library/src/main/kotlin/io/ashdavies/rx/rxtasks/TaskExtensions.kt
+++ b/library/src/main/kotlin/io/ashdavies/rx/rxtasks/TaskExtensions.kt
@@ -1,0 +1,9 @@
+package io.ashdavies.rx.rxtasks
+
+import com.google.android.gms.tasks.Task
+import io.reactivex.Completable
+import io.reactivex.Single
+
+fun Task<Void>.toCompletable(): Completable = Completable.create(CompletableTaskOnSubscribe(this))
+
+fun <T> Task<T>.toSingle(): Single<T> = Single.create(SingleTaskOnSubscribe(this))

--- a/library/src/main/kotlin/io/ashdavies/rx/rxtasks/TaskListenerFactory.kt
+++ b/library/src/main/kotlin/io/ashdavies/rx/rxtasks/TaskListenerFactory.kt
@@ -3,9 +3,9 @@ package io.ashdavies.rx.rxtasks
 import com.google.android.gms.tasks.OnFailureListener
 import com.google.android.gms.tasks.OnSuccessListener
 
-internal interface TaskListenerFactory<Result, in Emitter> {
+internal interface TaskListenerFactory<T, in E> {
 
-  fun createOnSuccessListener(emitter: Emitter): OnSuccessListener<Result>
+  fun createOnSuccessListener(emitter: E): OnSuccessListener<T>
 
-  fun createOnFailureListener(emitter: Emitter): OnFailureListener
+  fun createOnFailureListener(emitter: E): OnFailureListener
 }

--- a/library/src/main/kotlin/io/ashdavies/rx/rxtasks/TaskOnSubscribe.kt
+++ b/library/src/main/kotlin/io/ashdavies/rx/rxtasks/TaskOnSubscribe.kt
@@ -2,9 +2,9 @@ package io.ashdavies.rx.rxtasks
 
 import com.google.android.gms.tasks.Task
 
-internal abstract class TaskOnSubscribe<Result, in Emitter>(private val task: Task<Result>, private val factory: TaskListenerFactory<Result, Emitter>) {
+internal abstract class TaskOnSubscribe<T, in E>(private val task: Task<T>, private val factory: TaskListenerFactory<T, E>) {
 
-  fun subscribe(emitter: Emitter) {
+  fun subscribe(emitter: E) {
     task.addOnSuccessListener(factory.createOnSuccessListener(emitter))
     task.addOnFailureListener(factory.createOnFailureListener(emitter))
   }

--- a/library/src/test/kotlin/io/ashdavies/rx/rxtasks/CompletableEmitterFailureListenerTest.kt
+++ b/library/src/test/kotlin/io/ashdavies/rx/rxtasks/CompletableEmitterFailureListenerTest.kt
@@ -1,27 +1,18 @@
 package io.ashdavies.rx.rxtasks
 
+import com.nhaarman.mockito_kotlin.mock
 import io.reactivex.CompletableEmitter
-import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.BDDMockito.then
-import org.mockito.Mock
 import org.mockito.Mockito.never
-import org.mockito.junit.MockitoJUnitRunner
 import java.lang.Exception
 
-@RunWith(MockitoJUnitRunner::class)
 internal class CompletableEmitterFailureListenerTest {
 
-  private lateinit var listener: CompletableEmitterFailureListener
+  private val emitter = mock<CompletableEmitter>()
+  private val exception = mock<Exception>()
 
-  @Mock private lateinit var emitter: CompletableEmitter
-  @Mock private lateinit var exception: Exception
-
-  @Before
-  fun `set up`() {
-    listener = CompletableEmitterFailureListener(emitter)
-  }
+  private val listener = CompletableEmitterFailureListener(emitter)
 
   @Test
   fun `should call on error with exception`() {

--- a/library/src/test/kotlin/io/ashdavies/rx/rxtasks/CompletableEmitterSuccessListenerTest.kt
+++ b/library/src/test/kotlin/io/ashdavies/rx/rxtasks/CompletableEmitterSuccessListenerTest.kt
@@ -1,32 +1,20 @@
 package io.ashdavies.rx.rxtasks
 
 import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.mock
 import io.reactivex.CompletableEmitter
-import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.BDDMockito.then
-import org.mockito.Mock
 import org.mockito.Mockito.never
-import org.mockito.junit.MockitoJUnitRunner
 
-@RunWith(MockitoJUnitRunner::class)
 internal class CompletableEmitterSuccessListenerTest {
 
-  private lateinit var listener: CompletableEmitterSuccessListener
-
-  @Mock private lateinit var emitter: CompletableEmitter
-
-  @Before
-  fun `set up`() {
-    listener = CompletableEmitterSuccessListener(emitter)
-  }
+  private val emitter = mock<CompletableEmitter>()
+  private val listener = CompletableEmitterSuccessListener(emitter)
 
   @Test
-  @Ignore
   fun `should call on complete`() {
-    listener.onSuccess(null as Void)
+    listener.onSuccess(mock())
 
     then(emitter).should().onComplete()
     then(emitter).should(never()).onError(any())

--- a/library/src/test/kotlin/io/ashdavies/rx/rxtasks/CompletableTaskListenerFactoryTest.kt
+++ b/library/src/test/kotlin/io/ashdavies/rx/rxtasks/CompletableTaskListenerFactoryTest.kt
@@ -1,24 +1,14 @@
 package io.ashdavies.rx.rxtasks
 
 import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockito_kotlin.mock
 import io.reactivex.CompletableEmitter
-import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 
-@RunWith(MockitoJUnitRunner::class)
 internal class CompletableTaskListenerFactoryTest {
 
-  private lateinit var factory: TaskListenerFactory<Void, CompletableEmitter>
-
-  @Mock private lateinit var emitter: CompletableEmitter
-
-  @Before
-  fun `set up`() {
-    factory = CompletableTaskListenerFactory()
-  }
+  private val emitter = mock<CompletableEmitter>()
+  private val factory = CompletableTaskListenerFactory()
 
   @Test
   fun `should return completable emitter success listener`() {

--- a/library/src/test/kotlin/io/ashdavies/rx/rxtasks/CompletableTaskOnSubscribeTest.kt
+++ b/library/src/test/kotlin/io/ashdavies/rx/rxtasks/CompletableTaskOnSubscribeTest.kt
@@ -3,50 +3,40 @@ package io.ashdavies.rx.rxtasks
 import com.google.android.gms.tasks.OnFailureListener
 import com.google.android.gms.tasks.OnSuccessListener
 import com.google.android.gms.tasks.Task
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.willReturn
 import io.reactivex.CompletableEmitter
-import io.reactivex.CompletableOnSubscribe
-import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 
-@RunWith(MockitoJUnitRunner::class)
 internal class CompletableTaskOnSubscribeTest {
 
-  private lateinit var onSubscribe: CompletableOnSubscribe
+  private val task = mock<Task<Void>>()
+  private val emitter = mock<CompletableEmitter>()
+  private val factory = mock<TaskListenerFactory<Void, CompletableEmitter>>()
+  private val success = mock<OnSuccessListener<Void>>()
+  private val failure = mock<OnFailureListener>()
 
-  @Mock private lateinit var task: Task<Void>
-  @Mock private lateinit var emitter: CompletableEmitter
-
-  @Mock private lateinit var factory: TaskListenerFactory<Void, CompletableEmitter>
-  @Mock private lateinit var onSuccessListener: OnSuccessListener<Void>
-  @Mock private lateinit var onFailureListener: OnFailureListener
-
-  @Before
-  fun `set up`() {
-    onSubscribe = CompletableTaskOnSubscribe(task, factory)
-  }
+  private val subscribe = CompletableTaskOnSubscribe(task, factory)
 
   @Test
   fun `should subscribe with on success listener`() {
-    given(factory.createOnSuccessListener(emitter)).willReturn(onSuccessListener)
+    given(factory.createOnSuccessListener(emitter)).willReturn(success)
 
-    onSubscribe.subscribe(emitter)
+    subscribe.subscribe(emitter)
 
     then(factory).should().createOnSuccessListener(emitter)
-    then(task).should().addOnSuccessListener(onSuccessListener)
+    then(task).should().addOnSuccessListener(success)
   }
 
   @Test
   fun `should subscribe with on failure listener`() {
-    given(factory.createOnFailureListener(emitter)).willReturn(onFailureListener)
+    given(factory.createOnFailureListener(emitter)).willReturn(failure)
 
-    onSubscribe.subscribe(emitter)
+    subscribe.subscribe(emitter)
 
     then(factory).should().createOnFailureListener(emitter)
-    then(task).should().addOnFailureListener(onFailureListener)
+    then(task).should().addOnFailureListener(failure)
   }
 }

--- a/library/src/test/kotlin/io/ashdavies/rx/rxtasks/SingleEmitterFailureListenerTest.kt
+++ b/library/src/test/kotlin/io/ashdavies/rx/rxtasks/SingleEmitterFailureListenerTest.kt
@@ -1,27 +1,18 @@
 package io.ashdavies.rx.rxtasks
 
 import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.then
 import io.reactivex.SingleEmitter
-import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Mock
 import org.mockito.Mockito.never
-import org.mockito.junit.MockitoJUnitRunner
 
-@RunWith(MockitoJUnitRunner::class)
 class SingleEmitterFailureListenerTest {
 
-  private lateinit var listener: SingleEmitterFailureListener<String>
+  private val emitter = mock<SingleEmitter<Any>>()
+  private val exception = mock<Exception>()
 
-  @Mock private lateinit var emitter: SingleEmitter<String>
-  @Mock private lateinit var exception: Exception
-
-  @Before
-  fun `set up`() {
-    listener = SingleEmitterFailureListener(emitter)
-  }
+  private val listener = SingleEmitterFailureListener(emitter)
 
   @Test
   fun `should call on error with exception`() {

--- a/library/src/test/kotlin/io/ashdavies/rx/rxtasks/SingleEmitterSuccessListenerTest.kt
+++ b/library/src/test/kotlin/io/ashdavies/rx/rxtasks/SingleEmitterSuccessListenerTest.kt
@@ -1,26 +1,16 @@
 package io.ashdavies.rx.rxtasks
 
 import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.then
 import io.reactivex.SingleEmitter
-import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Mock
 import org.mockito.Mockito.never
-import org.mockito.junit.MockitoJUnitRunner
 
-@RunWith(MockitoJUnitRunner::class)
 class SingleEmitterSuccessListenerTest {
 
-  private lateinit var listener: SingleEmitterSuccessListener<String>
-
-  @Mock private lateinit var emitter: SingleEmitter<String>
-
-  @Before
-  fun `set up`() {
-    listener = SingleEmitterSuccessListener(emitter)
-  }
+  private val emitter = mock<SingleEmitter<Any>>()
+  private val listener = SingleEmitterSuccessListener(emitter)
 
   @Test
   fun `should call on success`() {
@@ -32,6 +22,6 @@ class SingleEmitterSuccessListenerTest {
 
   companion object {
 
-    private val RESULT = "SUCCESS"
+    private const val RESULT = "SUCCESS"
   }
 }

--- a/library/src/test/kotlin/io/ashdavies/rx/rxtasks/SingleTaskListenerFactoryTest.kt
+++ b/library/src/test/kotlin/io/ashdavies/rx/rxtasks/SingleTaskListenerFactoryTest.kt
@@ -1,24 +1,14 @@
 package io.ashdavies.rx.rxtasks
 
 import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockito_kotlin.mock
 import io.reactivex.SingleEmitter
-import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 
-@RunWith(MockitoJUnitRunner::class)
-class SingleTaskListenerFactoryTest {
+internal class SingleTaskListenerFactoryTest {
 
-  private lateinit var factory: TaskListenerFactory<Void, SingleEmitter<Void>>
-
-  @Mock private lateinit var emitter: SingleEmitter<Void>
-
-  @Before
-  fun `set up`() {
-    factory = SingleTaskListenerFactory()
-  }
+  private val emitter = mock<SingleEmitter<Any>>()
+  private val factory = SingleTaskListenerFactory<Any>()
 
   @Test
   fun `should return completable emitter success listener`() {

--- a/library/src/test/kotlin/io/ashdavies/rx/rxtasks/SingleTaskOnSubscribeTest.kt
+++ b/library/src/test/kotlin/io/ashdavies/rx/rxtasks/SingleTaskOnSubscribeTest.kt
@@ -4,49 +4,38 @@ import com.google.android.gms.tasks.OnFailureListener
 import com.google.android.gms.tasks.OnSuccessListener
 import com.google.android.gms.tasks.Task
 import com.nhaarman.mockito_kotlin.given
+import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.then
 import io.reactivex.SingleEmitter
-import io.reactivex.SingleOnSubscribe
-import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 
-@RunWith(MockitoJUnitRunner::class)
 class SingleTaskOnSubscribeTest {
 
-  private lateinit var onSubscribe: SingleOnSubscribe<String>
+  private val task = mock<Task<Any>>()
+  private val emitter = mock<SingleEmitter<Any>>()
+  private val factory = mock<TaskListenerFactory<Any, SingleEmitter<Any>>>()
+  private val success = mock<OnSuccessListener<Any>>()
+  private val failure = mock<OnFailureListener>()
 
-  @Mock private lateinit var task: Task<String>
-  @Mock private lateinit var emitter: SingleEmitter<String>
-
-  @Mock private lateinit var factory: TaskListenerFactory<String, SingleEmitter<String>>
-  @Mock private lateinit var onSuccessListener: OnSuccessListener<String>
-  @Mock private lateinit var onFailureListener: OnFailureListener
-
-  @Before
-  fun `set up`() {
-    onSubscribe = SingleTaskOnSubscribe(task, factory)
-  }
+  private val subscribe = SingleTaskOnSubscribe(task, factory)
 
   @Test
   fun `should subscribe with on success listener`() {
-    given(factory.createOnSuccessListener(emitter)).willReturn(onSuccessListener)
+    given(factory.createOnSuccessListener(emitter)).willReturn(success)
 
-    onSubscribe.subscribe(emitter)
+    subscribe.subscribe(emitter)
 
     then(factory).should().createOnSuccessListener(emitter)
-    then(task).should().addOnSuccessListener(onSuccessListener)
+    then(task).should().addOnSuccessListener(success)
   }
 
   @Test
   fun `should subscribe with on failure listener`() {
-    given(factory.createOnFailureListener(emitter)).willReturn(onFailureListener)
+    given(factory.createOnFailureListener(emitter)).willReturn(failure)
 
-    onSubscribe.subscribe(emitter)
+    subscribe.subscribe(emitter)
 
     then(factory).should().createOnFailureListener(emitter)
-    then(task).should().addOnFailureListener(onFailureListener)
+    then(task).should().addOnFailureListener(failure)
   }
 }

--- a/library/src/test/kotlin/io/ashdavies/rx/rxtasks/TaskExtensionsTest.kt
+++ b/library/src/test/kotlin/io/ashdavies/rx/rxtasks/TaskExtensionsTest.kt
@@ -4,31 +4,19 @@ import com.google.android.gms.tasks.OnSuccessListener
 import com.google.android.gms.tasks.Task
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockito_kotlin.argumentCaptor
+import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.then
-import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
-import java.lang.reflect.Constructor
 
-@RunWith(MockitoJUnitRunner::class)
-internal class RxTasksTest {
+internal class TaskExtensionsTest {
 
-  private lateinit var constructor: Constructor<RxTasks>
-
-  @Mock private lateinit var task: Task<Void>
-
-  @Before
-  fun `set up`() {
-    constructor = RxTasks::class.java.getDeclaredConstructor()
-  }
+  private val task = mock<Task<Void>>()
 
   @Test
   fun `should create completable task`() {
     val captor = argumentCaptor<OnSuccessListener<Void>>()
 
-    RxTasks.completable(task).subscribe()
+    task.toCompletable().subscribe()
 
     then(task).should().addOnSuccessListener(captor.capture())
     assertThat(captor.lastValue).isInstanceOf(CompletableEmitterSuccessListener::class.java)
@@ -38,9 +26,9 @@ internal class RxTasksTest {
   fun `should create single task`() {
     val captor = argumentCaptor<OnSuccessListener<Void>>()
 
-    RxTasks.completable(task).subscribe()
+    task.toSingle().subscribe()
 
     then(task).should().addOnSuccessListener(captor.capture())
-    assertThat(captor.lastValue).isInstanceOf(CompletableEmitterSuccessListener::class.java)
+    assertThat(captor.lastValue).isInstanceOf(SingleEmitterSuccessListener::class.java)
   }
 }

--- a/library/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/library/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/library/version.properties
+++ b/library/version.properties
@@ -1,0 +1,3 @@
+#Version of the produced binaries. This file is intended to be checked-in.
+#It will be automatically bumped by release automation.
+version=2.0.0

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -24,7 +24,7 @@ android {
 }
 
 dependencies {
-  api project(path: ':library', configuration: 'default')
+  implementation project(':library')
 
   implementation libraries.android.support.compat
   implementation libraries.kotlin

--- a/sample/src/main/kotlin/io/ashdavies/sample/MainActivity.kt
+++ b/sample/src/main/kotlin/io/ashdavies/sample/MainActivity.kt
@@ -2,9 +2,9 @@ package io.ashdavies.sample
 
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
-import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth
-import io.ashdavies.rx.rxtasks.RxTasks
+import io.ashdavies.rx.rxtasks.toCompletable
+import io.ashdavies.rx.rxtasks.toSingle
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
 import kotlinx.android.synthetic.main.activity_main.greeting
@@ -32,8 +32,10 @@ class MainActivity : AppCompatActivity() {
   }
 
   private fun signInAnonymously() {
-    disposables += RxTasks.single<AuthResult>(FirebaseAuth.getInstance().signInAnonymously())
-        .subscribe { result -> greetAnonymousUser(result.getUser().getUid()) }
+    disposables += FirebaseAuth.getInstance()
+        .signInAnonymously()
+        .toSingle()
+        .subscribe { result -> greetAnonymousUser(result.user.uid) }
   }
 
   private fun greetAnonymousUser(user: String) {


### PR DESCRIPTION
- [x] Remove usage of `MockitoJUnitRunner` in favour of direct mock instantiation
- [x] Provide task extensions is priority entry point
- [x] Change `RxTasks` to generic object
- [x] Update project dependencies
- [x] Update documentation for task extensions