### PR TITLE
Fix for extensions not being visible outside of module

### DIFF
--- a/library/src/main/kotlin/io/ashdavies/rx/rxtasks/RxTasks.kt
+++ b/library/src/main/kotlin/io/ashdavies/rx/rxtasks/RxTasks.kt
@@ -1,10 +1,12 @@
 package io.ashdavies.rx.rxtasks
 
 import com.google.android.gms.tasks.Task
+import io.reactivex.Completable
+import io.reactivex.Single
 
 object RxTasks {
 
-  fun completable(task: Task<Void>) = task.toCompletable()
+  fun completable(task: Task<Void>): Completable = Completable.create(CompletableTaskOnSubscribe(task))
 
-  fun <T> single(task: Task<T>) = task.toSingle()
+  fun <T> single(task: Task<T>): Single<T> = Single.create(SingleTaskOnSubscribe(task))
 }

--- a/library/src/main/kotlin/io/ashdavies/rx/rxtasks/TaskExtensions.kt
+++ b/library/src/main/kotlin/io/ashdavies/rx/rxtasks/TaskExtensions.kt
@@ -1,9 +1,10 @@
+// for single function call, inlining is just fine
+@file:Suppress("NOTHING_TO_INLINE")
+
 package io.ashdavies.rx.rxtasks
 
 import com.google.android.gms.tasks.Task
-import io.reactivex.Completable
-import io.reactivex.Single
 
-fun Task<Void>.toCompletable(): Completable = Completable.create(CompletableTaskOnSubscribe(this))
+inline fun Task<Void>.toCompletable() = RxTasks.completable(this)
 
-fun <T> Task<T>.toSingle(): Single<T> = Single.create(SingleTaskOnSubscribe(this))
+inline fun <T> Task<T>.toSingle() = RxTasks.single(this)


### PR DESCRIPTION
Flip around implementations of the RxTasks/TaskExtensions so that the extensions will be visible outside of the module.