### PR TITLE
Allow specifying the scheduler

### DIFF
--- a/library/src/main/kotlin/io/ashdavies/rx/rxtasks/CompletableTaskListenerFactory.kt
+++ b/library/src/main/kotlin/io/ashdavies/rx/rxtasks/CompletableTaskListenerFactory.kt
@@ -1,10 +1,11 @@
 package io.ashdavies.rx.rxtasks
 
 import io.reactivex.CompletableEmitter
+import io.reactivex.Scheduler
 
-internal class CompletableTaskListenerFactory : TaskListenerFactory<Void, CompletableEmitter> {
+internal class CompletableTaskListenerFactory constructor(override val scheduler: Scheduler? = null) : TaskListenerFactory<Void, CompletableEmitter> {
 
   override fun createOnSuccessListener(emitter: CompletableEmitter) = CompletableEmitterSuccessListener(emitter)
 
-  override fun createOnFailureListener(emitter: CompletableEmitter)= CompletableEmitterFailureListener(emitter)
+  override fun createOnFailureListener(emitter: CompletableEmitter) = CompletableEmitterFailureListener(emitter)
 }

--- a/library/src/main/kotlin/io/ashdavies/rx/rxtasks/RxTasks.kt
+++ b/library/src/main/kotlin/io/ashdavies/rx/rxtasks/RxTasks.kt
@@ -1,10 +1,13 @@
 package io.ashdavies.rx.rxtasks
 
 import com.google.android.gms.tasks.Task
+import io.reactivex.Scheduler
 
 object RxTasks {
 
   fun completable(task: Task<Void>) = task.toCompletable()
+  fun completable(task: Task<Void>, scheduler: Scheduler) = task.toCompletable(scheduler)
 
   fun <T> single(task: Task<T>) = task.toSingle()
+  fun <T> single(task: Task<T>, scheduler: Scheduler) = task.toSingle(scheduler)
 }

--- a/library/src/main/kotlin/io/ashdavies/rx/rxtasks/SingleTaskListenerFactory.kt
+++ b/library/src/main/kotlin/io/ashdavies/rx/rxtasks/SingleTaskListenerFactory.kt
@@ -1,8 +1,9 @@
 package io.ashdavies.rx.rxtasks
 
+import io.reactivex.Scheduler
 import io.reactivex.SingleEmitter
 
-internal class SingleTaskListenerFactory<T> : TaskListenerFactory<T, SingleEmitter<T>> {
+internal class SingleTaskListenerFactory<T> constructor(override val scheduler: Scheduler? = null) : TaskListenerFactory<T, SingleEmitter<T>> {
 
   override fun createOnSuccessListener(emitter: SingleEmitter<T>) = SingleEmitterSuccessListener(emitter)
 

--- a/library/src/main/kotlin/io/ashdavies/rx/rxtasks/TaskExtensions.kt
+++ b/library/src/main/kotlin/io/ashdavies/rx/rxtasks/TaskExtensions.kt
@@ -2,8 +2,12 @@ package io.ashdavies.rx.rxtasks
 
 import com.google.android.gms.tasks.Task
 import io.reactivex.Completable
+import io.reactivex.Scheduler
 import io.reactivex.Single
 
 fun Task<Void>.toCompletable(): Completable = Completable.create(CompletableTaskOnSubscribe(this))
+fun Task<Void>.toCompletable(scheduler: Scheduler): Completable =
+  Completable.create(CompletableTaskOnSubscribe(this, CompletableTaskListenerFactory(scheduler)))
 
 fun <T> Task<T>.toSingle(): Single<T> = Single.create(SingleTaskOnSubscribe(this))
+fun <T> Task<T>.toSingle(scheduler: Scheduler): Single<T> = Single.create(SingleTaskOnSubscribe(this, SingleTaskListenerFactory(scheduler)))

--- a/library/src/main/kotlin/io/ashdavies/rx/rxtasks/TaskListenerFactory.kt
+++ b/library/src/main/kotlin/io/ashdavies/rx/rxtasks/TaskListenerFactory.kt
@@ -2,10 +2,14 @@ package io.ashdavies.rx.rxtasks
 
 import com.google.android.gms.tasks.OnFailureListener
 import com.google.android.gms.tasks.OnSuccessListener
+import io.reactivex.Scheduler
 
 internal interface TaskListenerFactory<T, in E> {
 
   fun createOnSuccessListener(emitter: E): OnSuccessListener<T>
 
   fun createOnFailureListener(emitter: E): OnFailureListener
+
+  /** optional scheduler to use for receiving results. if null, main thread will be used. */
+  val scheduler: Scheduler?
 }

--- a/library/src/main/kotlin/io/ashdavies/rx/rxtasks/TaskOnSubscribe.kt
+++ b/library/src/main/kotlin/io/ashdavies/rx/rxtasks/TaskOnSubscribe.kt
@@ -1,11 +1,19 @@
 package io.ashdavies.rx.rxtasks
 
 import com.google.android.gms.tasks.Task
+import java.util.concurrent.Executor
 
 internal abstract class TaskOnSubscribe<T, in E>(private val task: Task<T>, private val factory: TaskListenerFactory<T, E>) {
 
   fun subscribe(emitter: E) {
-    task.addOnSuccessListener(factory.createOnSuccessListener(emitter))
-    task.addOnFailureListener(factory.createOnFailureListener(emitter))
+    val scheduler = factory.scheduler
+    if (scheduler == null) {
+      task.addOnSuccessListener(factory.createOnSuccessListener(emitter))
+      task.addOnFailureListener(factory.createOnFailureListener(emitter))
+    } else {
+      val executor = Executor { scheduler.scheduleDirect(it) }
+      task.addOnSuccessListener(executor, factory.createOnSuccessListener(emitter))
+      task.addOnFailureListener(executor, factory.createOnFailureListener(emitter))
+    }
   }
 }


### PR DESCRIPTION
Allow specifying the scheduler when observing task results to directly receive task results on thread other than main thread.