### PR TITLE
Allow null emissions to success for completable

### DIFF
--- a/library/src/main/kotlin/io/ashdavies/rx/rxtasks/CompletableEmitterSuccessListener.kt
+++ b/library/src/main/kotlin/io/ashdavies/rx/rxtasks/CompletableEmitterSuccessListener.kt
@@ -5,5 +5,5 @@ import io.reactivex.CompletableEmitter
 
 internal class CompletableEmitterSuccessListener(private val emitter: CompletableEmitter) : OnSuccessListener<Void> {
 
-  override fun onSuccess(void: Void) = emitter.onComplete()
+  override fun onSuccess(void: Void?) = emitter.onComplete()
 }


### PR DESCRIPTION
I'm using this for Firestore DB writes and this API is emitting null into the onSuccess() after a write:

https://firebase.google.com/docs/reference/android/com/google/firebase/firestore/DocumentReference.html#set(java.lang.Object, com.google.firebase.firestore.SetOptions)

This triggers a kotlin nullability error.  Updating the` CompletableEmitterSuccessListener` to allow null values fixes the issue.